### PR TITLE
buildLibrary to increase package version

### DIFF
--- a/.buildlibrary
+++ b/.buildlibrary
@@ -1,4 +1,4 @@
-ValidationKey: '218922'
+ValidationKey: '239400'
 AutocreateReadme: yes
 AcceptedWarnings:
 - 'Warning: package ''.*'' was built under R version'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo: https://github.com/lorenzwalthert/precommit
-    rev: 7910e0323d7213f34275a7a562b9ef0fde8ce1b9  # frozen: v0.4.2
+    rev: bae853d82da476eee0e0a57960ee6b741a3b3fb7  # frozen: v0.4.3
     hooks:
     -   id: parsable-R
     -   id: deps-in-desc

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite it using the metadata from this file.
 type: software
 title: 'piamutils: Utilities for the piam-verse'
-version: 0.0.11
-date-released: '2024-06-28'
+version: 0.0.12
+date-released: '2024-08-15'
 abstract: This package contains utilities and helpers needed in various piam libraries.
 authors:
 - family-names: Benke

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: piamutils
 Title: Utilities for the piam-verse
-Version: 0.0.11
-Date: 2024-06-28
+Version: 0.0.12
+Date: 2024-08-15
 Authors@R: c(
     person("Falk", "Benke", , "benke@pik-potsdam.de", role = c("aut", "cre")),
     person("Christof", "Schötz", role = "aut")
@@ -17,4 +17,4 @@ Imports:
 Suggests:
     testthat
 Encoding: UTF-8
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Utilities for the piam-verse
 
-R package **piamutils**, version **0.0.11**
+R package **piamutils**, version **0.0.12**
 
 [![CRAN status](https://www.r-pkg.org/badges/version/piamutils)](https://cran.r-project.org/package=piamutils)  [![R build status](https://github.com/pik-piam/piamutils/workflows/check/badge.svg)](https://github.com/pik-piam/piamutils/actions) [![codecov](https://codecov.io/gh/pik-piam/piamutils/branch/master/graph/badge.svg)](https://app.codecov.io/gh/pik-piam/piamutils) [![r-universe](https://pik-piam.r-universe.dev/badges/piamutils)](https://pik-piam.r-universe.dev/builds)
 
@@ -38,7 +38,7 @@ In case of questions / problems please contact Falk Benke <benke@pik-potsdam.de>
 
 To cite package **piamutils** in publications use:
 
-Benke F, Schötz C (2024). _piamutils: Utilities for the piam-verse_. R package version 0.0.11, <https://github.com/pik-piam/piamutils>.
+Benke F, Schötz C (2024). _piamutils: Utilities for the piam-verse_. R package version 0.0.12, <https://github.com/pik-piam/piamutils>.
 
 A BibTeX entry for LaTeX users is
 
@@ -47,7 +47,7 @@ A BibTeX entry for LaTeX users is
   title = {piamutils: Utilities for the piam-verse},
   author = {Falk Benke and Christof Schötz},
   year = {2024},
-  note = {R package version 0.0.11},
+  note = {R package version 0.0.12},
   url = {https://github.com/pik-piam/piamutils},
 }
 ```


### PR DESCRIPTION
was somehow missed in #10 leading to:
```
Attaching package: 'piamutils'

The following object is masked from 'package:magclass':

    matchDim
```